### PR TITLE
NoMethodError: undefined method `strip' for 10022:Fixnum

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -36,7 +36,7 @@ end
 def config_fragment
   x = "Host #{new_resource.host.strip}\n"
   new_resource.options.each {|key, value|
-    x += "  #{key} #{value.strip}\n"
+    x += "  #{key} #{value.to_s.strip}\n"
   }
   x += "#End Chef SSH for #{new_resource.host.strip}\n"
   return x


### PR DESCRIPTION
``` ruby
ssh_config "test.com" do
  options 'User' => 'test', 'Port' => 10022
  user 'test'
end
```
