### PR TITLE
Update metadata.rb to fix cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "ssh"
 maintainer       "Mark Olson"
 maintainer_email "theothermarkolson@gmail.com"
 license          "Apache 2.0"


### PR DESCRIPTION
The cookbook wasn't working for me until I gave it the name "ssh". I'm using berkshelf so that might have had something to do with it. 
