### PR TITLE
Changing the way to find the user's .ssh directory to be more reliable

### DIFF
--- a/libraries/ssh_path_helpers.rb
+++ b/libraries/ssh_path_helpers.rb
@@ -6,8 +6,7 @@ class Chef
         filename = File.basename(default)
         ssh_path = nil
         if (new_resource.user && !new_resource.path)
-	  prefix = new_resource.user == "root" ? "" : "/home"
-          ssh_path = "#{prefix}/#{new_resource.user}/.ssh/#{filename.gsub('ssh_','')}"
+          ssh_path = "#{node['etc']['passwd'][new_resource.user]['dir']}/.ssh/#{filename.gsub('ssh_','')}"
         elsif new_resource.path
           ssh_path = new_resource.path
         else


### PR DESCRIPTION
Using the built in info from ohai which will tell us where the user's home dir. Not all users have a home dir under /home
