### PR TITLE
Allow for a port number to be included in the hostname for the known_hosts resource

### DIFF
--- a/test/cookbooks/ssh_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/ssh_test/files/default/tests/minitest/default_test.rb
@@ -31,4 +31,8 @@ describe_recipe 'ssh::default' do
     file("/tmp/bitty/.ssh/known_hosts").must_include 'github.com'
   end
 
+  it "creates a 'faked' known_hosts entry for a host with specified port" do
+    file("/tmp/bitty/.ssh/known_hosts").must_include 'gitlab.com'
+  end
+
 end

--- a/test/cookbooks/ssh_test/recipes/default.rb
+++ b/test/cookbooks/ssh_test/recipes/default.rb
@@ -44,3 +44,8 @@ ssh_config "github.com" do
   options 'User' => 'git', 'IdentityFile' => '/tmp/gh'
   user 'faked'
 end
+
+ssh_known_hosts "gitlab.com:22" do
+  hashed false
+  user 'faked'
+end


### PR DESCRIPTION
I needed to specify a port number when adding a known_hosts entry, and it seems as though ssh-keyscan doesn't use ~/.ssh/config, so I figured allowing a port number to be included in the hostname for the resource would probably be the simplest way to do this.
