### PR TITLE
Fix debug logging

### DIFF
--- a/providers/known_hosts.rb
+++ b/providers/known_hosts.rb
@@ -6,7 +6,7 @@ action :add do
   known_hosts_path = default_or_user_path(node['ssh']['known_hosts_path'], ssh_user)
   host, port = new_resource.host.split(':')
   # set the port to the default (22) if it wasn't already set
-  port = new_resource.port unless port 
+  port = new_resource.port unless port
 
   key = new_resource.key
   if key.nil?

--- a/test/cookbooks/ssh_test/files/default/tests/minitest/default_test.rb
+++ b/test/cookbooks/ssh_test/files/default/tests/minitest/default_test.rb
@@ -1,5 +1,5 @@
 require 'minitest/spec'
- 
+
 describe_recipe 'ssh::default' do
   it "creates a 'root' config" do
     file("/root/.ssh/config").must_exist.with(:mode, "600").with(:owner, "root")


### PR DESCRIPTION
Without this change I encounter the following error when converging in debug mode under Chef 11.8.2:

`[2013-12-23T22:31:29+00:00] ERROR: ssh_known_hosts[github.com] (ssh_test::default line 3) had an error: NameError: Cannot find a resource for only_if on ubuntu version 12.04`
