### PR TITLE
Bump version to 0.6.6.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "theothermarkolson@gmail.com"
 license          "Apache 2.0"
 description      "LWRPs for managing SSH known_hosts and config files"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.6.5"
+version          "0.6.6"


### PR DESCRIPTION
Hi,

This is just a request to bump up the version number to 0.6.6, which include the following changes https://github.com/markolson/chef-ssh/compare/52837a3f8c5e319d40f3dae917df329e6d95e7b3...master

Would you also mind creating two tags for `0.6.5` and `0.6.6`?
It can be done as follow:

``` bash
git checkout 52837a3f
git tag 0.6.5
git checkout master 
git tag 0.6.6
git push --tags
```

This would be very helpful for people using dependency management such as Berkshelf and Librarian.

Cheers
