### PR TITLE
Add group option to ssh_config resource/provider

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,34 +1,36 @@
 include Chef::SSH::PathHelpers
 action :add do
   ssh_user = new_resource.user || 'root'
+  ssh_group = new_resource.group || ssh_user
   ssh_config_path = default_or_user_path(node['ssh']['config_path'], ssh_user)
 
-  remove_entry(ssh_config_path, ssh_user)
-  add_entry(ssh_config_path, ssh_user)
-  set_rights_proper(ssh_config_path, ssh_user)
+  remove_entry(ssh_config_path, ssh_user, ssh_group)
+  add_entry(ssh_config_path, ssh_user, ssh_group)
+  set_rights_proper(ssh_config_path, ssh_user, ssh_group)
 end
 
 action :remove do
   ssh_user = new_resource.user || 'root'
+  ssh_group = new_resource.group || ssh_user
   ssh_config_path = default_or_user_path(node['ssh']['config_path'], ssh_user)
 
   remove_entry(ssh_config_path, ssh_user)
 end
 
-def remove_entry(config_file, ssh_user)
+def remove_entry(config_file, ssh_user, ssh_group)
   execute "remove #{new_resource.host} from #{config_file}" do
     command "ruby -e 'x =  $<.read; x.gsub!(/^[\n]{0,1}Host #{new_resource.host.strip}.*#End Chef SSH for #{new_resource.host.strip}\n/m,\"\"); puts x' #{config_file} > #{config_file}.new && mv #{config_file}.new #{config_file}"
     user ssh_user
-    group ssh_user
+    group ssh_group
     only_if "grep \"#{new_resource.host}\" #{config_file}"
   end
 end
 
-def add_entry(config_file, ssh_user)
+def add_entry(config_file, ssh_user, ssh_group)
   execute "add #{new_resource.host} to #{config_file}" do
     command "echo '#{config_fragment}' >> #{config_file}"
     user ssh_user
-    group ssh_user
+    group ssh_group
     umask 600
   end
 end
@@ -42,10 +44,10 @@ def config_fragment
   return x
 end
 
-def set_rights_proper(config_file, ssh_user)
+def set_rights_proper(config_file, ssh_user, ssh_group)
   file "#{config_file}" do
     owner ssh_user
-    group ssh_user
+    group ssh_group
     mode "0600"
     action :create
   end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -4,6 +4,7 @@ default_action :add
 attribute :host,    :kind_of => String, :name_attribute => true
 attribute :options, :kind_of => Hash
 attribute :user,    :kind_of => String
+attribute :group,   :kind_of => String
 attribute :path,    :kind_of => String
 
 def initialize(*args)


### PR DESCRIPTION
In many circumstances, users do not have a group with a matching name, particularly when the user is sourced from LDAP. This PR adds a `group` attribute to the `ssh_config` resource so it does not explode spectacularly.
