### PR TITLE
Fix/Adapt regex for HostName option when parsing file

### DIFF
--- a/libraries/ssh_config_helpers.rb
+++ b/libraries/ssh_config_helpers.rb
@@ -19,7 +19,7 @@ class Chef
         IO.foreach(path) do |line|
           next if line.match(/^\s*(#|\r?\n|\s*$)/) # skip lines with only comments or whitespace
 
-          matchdata = line.match(/^\s*([h|H]ost)(.*$)/)
+          matchdata = line.match(/^\s*([h|H]ost\s)(.*$)/)
           if matchdata
             name = matchdata.captures[1].strip
             entries[name] = {}

--- a/libraries/ssh_config_helpers.rb
+++ b/libraries/ssh_config_helpers.rb
@@ -19,7 +19,7 @@ class Chef
         IO.foreach(path) do |line|
           next if line.match(/^\s*(#|\r?\n|\s*$)/) # skip lines with only comments or whitespace
 
-          matchdata = line.match(/^\s*([h|H]ost\s)(.*$)/)
+          matchdata = line.match(/^\s*([h|H]ost\s+)(.*$)/)
           if matchdata
             name = matchdata.captures[1].strip
             entries[name] = {}

--- a/spec/provider_tests/config_spec.rb
+++ b/spec/provider_tests/config_spec.rb
@@ -21,6 +21,7 @@ describe 'ssh_config resource' do
     content << 'and_also_with=equal sign'
     content << 'Host second with extra patterns'
     content << '  Extra_spaces    did_not_matter'
+    content << '  HostName option is correctly matched'
     content << '  Multiple_words not a problem'
     content << '  We "can handle quotes"'
   end
@@ -39,6 +40,7 @@ describe 'ssh_config resource' do
     content << ''
     content << 'Host second with extra patterns'
     content << '  Extra_spaces did_not_matter'
+    content << '  HostName option is correctly matched'
     content << '  Multiple_words not a problem'
     content << '  We "can handle quotes"'
     content << ''


### PR DESCRIPTION
Old regex match "HostName ..." as a Host entry that generate an
invalid ssh configuration file.