### PR TITLE
Install ssh package only if OS is debian family.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,8 @@
 # Cookbook: ssh
 # Recipe: default.rb
 
-package 'ssh' do
-  action :install
+if node[:platform_faily].include?("debian")
+  package 'ssh' do
+    action :install
+  end
 end


### PR DESCRIPTION
Running ssh cookbook on RHEL OS occurs error because there is no ssh package in yum.