### PR TITLE
Matching bug when Host contains brackets

### DIFF
--- a/providers/known_hosts.rb
+++ b/providers/known_hosts.rb
@@ -77,7 +77,7 @@ end
 def load_current_resource
   search = Mixlib::ShellOut.new(
     "ssh-keygen -H -F #{Shellwords.escape(new_resource.host)} "\
-    "-f #{new_resource.path} | grep 'Host #{new_resource.host} found'"
+    "-f #{new_resource.path} | grep -F 'Host #{new_resource.host} found'"
   )
   search.run_command
   @current_resource = Chef::Resource::SshKnownHosts.new(@new_resource.name)


### PR DESCRIPTION
When a host contains brackets or other special characters from regex, it won't be match by new_resource.exists? and will end up appended to ssh_known_hosts at each chef run.

Grep needs to be use in fixed-string mode when comparing with Host with port like [git.example.com]:1234

This PR corrects the issue, thanks for merging.