### PR TITLE
refactoring OS based package selection

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,8 +2,6 @@ default['ssh']['known_hosts_path'] = '/etc/ssh/ssh_known_hosts'
 default['ssh']['config_path'] = '/etc/ssh/ssh_config'
 
 case node['platform_family']
-when 'debian'
-  default['ssh']['packages'] = ['ssh']
 when 'rhel'
   default['ssh']['packages'] = ['openssh-server', 'openssh-clients']
 else


### PR DESCRIPTION
No need to check for Debian based OSes as it defaults to `ssh` as well