### PR TITLE
Allow comments in authorized_keys files

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tejay.cardon@gmail.com'
 license          'Apache 2.0'
 description      'LWRPs for managing SSH known_hosts and config files'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.10.16'
+version          '0.10.17'
 issues_url 'https://github.com/markolson/chef-ssh/issues'
 source_url 'https://github.com/markolson/chef-ssh'
 


### PR DESCRIPTION
SSH authorized_keys files may contain comments (lines starting with '#'). This PR adds handling for comment lines and also fixes an error with a missing parameter in validate_*_option.
