### PR TITLE
known_hosts idempotence bug when using a non-default SSH port

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ some of your cookbooks may not be as generous.
       <td><code>nil</code></td>
     </tr>
     <tr>
+      <td>port</td>
+      <td>
+        The host's SSH port
+      </td>
+      <td><code>22</code></td>
+    </tr>
+    <tr>
       <td>hashed</td>
       <td>A Boolean indicating if SSH is configured to use a hashed `known_hosts` file.
       </td>

--- a/providers/known_hosts.rb
+++ b/providers/known_hosts.rb
@@ -75,9 +75,10 @@ def load_key_if_needed
 end
 
 def load_current_resource
+  matching_host = new_resource.port == 22 ? new_resource.host : "[#{new_resource.host}]:#{new_resource.port}"
   search = Mixlib::ShellOut.new(
-    "ssh-keygen -H -F #{Shellwords.escape(new_resource.host)} "\
-    "-f #{new_resource.path} | grep 'Host #{new_resource.host} found'"
+    "ssh-keygen -H -F #{Shellwords.escape(matching_host)} "\
+    "-f #{new_resource.path} | grep -F 'Host #{matching_host} found'"
   )
   search.run_command
   @current_resource = Chef::Resource::SshKnownHosts.new(@new_resource.name)

--- a/test/cookbooks/ssh_test/libraries/test_data.rb
+++ b/test/cookbooks/ssh_test/libraries/test_data.rb
@@ -8,6 +8,16 @@ module TestData
     '8G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
   end
 
+  def self.bitbucket_altssh_key
+    '[altssh.bitbucket.org]:443 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubi'\
+    'N81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYK'\
+    'iEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusM'\
+    'EASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9'\
+    'IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjO'\
+    'bPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBo'\
+    'GqzHM9yXw=='
+  end
+
   def self.dummy1_key
     'dummy1 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSw'\
     'BK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV'\

--- a/test/cookbooks/ssh_test/recipes/known_hosts.rb
+++ b/test/cookbooks/ssh_test/recipes/known_hosts.rb
@@ -23,6 +23,16 @@ ssh_known_hosts 'github.com' do
   port   22
 end
 
+# Simulate multiple converges to test idempotence
+(1..3).step do |n|
+  ssh_known_hosts "altssh.bitbucket.org converge #{n}" do
+    host 'altssh.bitbucket.org'
+    port 443
+    user 'root'
+    key ::TestData.bitbucket_altssh_key
+  end
+end
+
 ssh_known_hosts 'some entry' do
   host 'test_host'
   user 'vagrant'

--- a/test/integration/known_hosts/serverspec/known_hosts_spec.rb
+++ b/test/integration/known_hosts/serverspec/known_hosts_spec.rb
@@ -21,6 +21,10 @@ describe command('ssh-keygen -F github.com -f /home/vagrant/.ssh/known_hosts') d
   its(:stdout) { should match(/found/) }
 end
 
+describe command('ssh-keygen -F [altssh.bitbucket.org]:443 -f /root/.ssh/known_hosts | grep found | wc -l') do
+  its(:stdout) { should match(/1/) }
+end
+
 describe file('/home/vagrant/.ssh/known_hosts') do
   it { should be_file }
   its(:content) { should match(/\[dummy6\]\:234 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwDBTE5H\+DpOWUv3CPtOo/) }


### PR DESCRIPTION
When you use the `known_hosts` resource with a SSH port other than 22, the host entry gets duplicated after every converge because the matching in `load_current_resource` is incorrect.

symptoms after 3 converges:

```
> cat /root/.ssh/known_hosts
[altssh.bitbucket.org]:443 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
[altssh.bitbucket.org]:443 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
[altssh.bitbucket.org]:443 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
```

This PR fixes the problem and covers it with a test that make sure the entry gets added only once.

```
# Simulate multiple converges to test idempotence
(1..3).step do |n|
  ssh_known_hosts "altssh.bitbucket.org converge #{n}" do
    host 'altssh.bitbucket.org'
    port 443
    user 'root'
    key ::TestData.bitbucket_altssh_key
  end
end
```

```
describe command('ssh-keygen -F [altssh.bitbucket.org]:443 -f /root/.ssh/known_hosts | grep found | wc -l') do
  its(:stdout) { should match(/1/) }
end
```
