### PR TITLE
LWRP resources no longer work using constant names, this fixes it for…

### DIFF
--- a/providers/authorized_keys.rb
+++ b/providers/authorized_keys.rb
@@ -80,7 +80,7 @@ def load_current_resource
   @lines = ::File.exist?(@path) ? parse(::IO.readlines(@path)) : []
 
   current_line = @lines.find { |line| line.is_a?(Hash) && line[:key] == @new_resource.key }
-  @current_resource = Chef::Resource::SshKnownHosts.new(@new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(:ssh_known_hosts, node).new(@new_resource.name)
   @current_resource.exists = current_line
 end
 

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -54,6 +54,6 @@ def load_current_resource
   @path = new_resource.path || default_or_user_path(new_resource.user)
   @existing_entries = parse_file @path
 
-  @current_resource = Chef::Resource::SshConfig.new(@new_resource.host)
+  @current_resource = Chef::Resource::resource_for_node(:ssh_config, node).new(@new_resource.host)
   @current_resource.exists = @existing_entries.key? @new_resource.host
 end

--- a/providers/known_hosts.rb
+++ b/providers/known_hosts.rb
@@ -87,7 +87,7 @@ def load_current_resource
 
   search = Mixlib::ShellOut.new(cmd)
   search.run_command
-  @current_resource = Chef::Resource::SshKnownHosts.new(@new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(:ssh_known_hosts, node).new(@new_resource.name)
   @current_resource.exists = search.status.success?
 end
 


### PR DESCRIPTION
This should solve at least for now the issue with chef 13. ( Issue #70 ).

The kitchen test pass with version 12.20.3 and 13.0.118.

There's only one problem that tests use an external cookbook that is not yet chef 13 complian and has the same problem, but used the cookbook on one of mines and te test for authorized_keys passes.